### PR TITLE
issue/92 手機結帳無法執行create action修復

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,7 +1,7 @@
 class OrdersController < ApplicationController
   before_action :find_desk, only: [:create]
   before_action :find_order, only: [:destroy, :pay, :serve]
-  # before_action :authenticate_user!
+  before_action :authenticate_user!
   skip_before_action :verify_authenticity_token, only: [:checkout, :response]
 
   def create


### PR DESCRIPTION
1. 加入需登入的條件
2. 會導致找不到orders的原因，是因為沒有登入，無法用使用者建立訂單資訊